### PR TITLE
fix: recognize works with files now

### DIFF
--- a/shaq/_cli.py
+++ b/shaq/_cli.py
@@ -96,11 +96,11 @@ def _listen(console: Console, args: argparse.Namespace) -> bytearray:
 
 def _from_file(console: Console, args: argparse.Namespace) -> AudioSegment:
     with Status(f"Extracting from {args.input}", console=console):
-        input = AudioSegment.from_file(args.input)
-
-        # pydub measures things in milliseconds
-        duration = args.duration * 1000
-        return input[:duration]
+        data = AudioSegment.from_file(args.input, duration=args.duration)
+        
+        buffer = data.export(format="wav")
+        audio_data = buffer.read()
+        return audio_data
 
 
 async def _shaq(console: Console, args: argparse.Namespace) -> dict[str, Any]:
@@ -112,7 +112,7 @@ async def _shaq(console: Console, args: argparse.Namespace) -> dict[str, Any]:
 
     shazam = Shazam(language="en-US", endpoint_country="US")
 
-    return await shazam.recognize_song(input, proxy=args.proxy)  # type: ignore
+    return await shazam.recognize(input, proxy=args.proxy)  # type: ignore
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -178,7 +178,8 @@ def main() -> None:
             sys.exit(1)
 
         try:
-            raw = asyncio.run(_shaq(console, args))
+            loop = asyncio.get_event_loop()
+            raw = loop.run_until_complete(_shaq(console, args))
             track = Serialize.full_track(raw)
         except KeyboardInterrupt:
             console.print("[red]Interrupted.[/red]")


### PR DESCRIPTION
- exporting to wav then passing bytes to ShazamIO (see [this comment](https://www.github.com/shazamio/ShazamIO/issues/103#issuecomment-2081220779) )
- pass duration to from_file in seconds ( It accepts seconds: https://github.com/jiaaro/pydub/blob/996cec42e9621701edb83354232b2c0ca0121560/pydub/audio_segment.py#L672-L696 )
- Fix `RuntimeError: Event loop is closed`